### PR TITLE
管理人が他のユーザーのパスワードも変更できるようにする

### DIFF
--- a/qa-admin-change-password-layer.php
+++ b/qa-admin-change-password-layer.php
@@ -9,7 +9,7 @@ class qa_html_theme_layer extends qa_html_theme_base
 			if (qa_get_state() == 'edit' && qa_get_logged_in_level() >= QA_USER_LEVEL_SUPER ) {
 				// print_r($this->content);
 				$this->content['form_password'] = array(
-					'tags' => 'method="post" action="'.qa_opt('site_url').'test-plugin"',
+					'tags' => 'method="post" action="'.qa_opt('site_url').'change-password"',
 
 					'style' => 'wide',
 

--- a/qa-admin-change-password-layer.php
+++ b/qa-admin-change-password-layer.php
@@ -1,0 +1,62 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+
+	function main()
+	{
+		if ($this->template == 'user') {
+			if (qa_get_state() == 'edit' && qa_get_logged_in_level() >= QA_USER_LEVEL_SUPER ) {
+				// print_r($this->content);
+				$this->content['form_password'] = array(
+					'tags' => 'method="post" action="'.qa_opt('site_url').'test-plugin"',
+
+					'style' => 'wide',
+
+					'title' => qa_lang_html('users/change_password'),
+
+					'fields' => array(
+						'old' => array(
+							'label' => qa_lang_html('users/old_password'),
+							'tags' => 'name="oldpassword"',
+							'value' => qa_html(@$inoldpassword),
+							'type' => 'password',
+							'error' => qa_html(@$errors['oldpassword']),
+						),
+
+						'new_1' => array(
+							'label' => qa_lang_html('users/new_password_1'),
+							'tags' => 'name="newpassword1"',
+							'type' => 'password',
+							'error' => qa_html(@$errors['password']),
+						),
+
+						'new_2' => array(
+							'label' => qa_lang_html('users/new_password_2'),
+							'tags' => 'name="newpassword2"',
+							'type' => 'password',
+							'error' => qa_html(@$errors['newpassword2']),
+						),
+					),
+
+					'buttons' => array(
+						'change' => array(
+							'label' => qa_lang_html('users/change_password'),
+						),
+					),
+
+					'hidden' => array(
+						'dochangepassword' => '1',
+						'code' => qa_get_form_security_code('password'),
+						'userid' => $this->content['raw']['userid'],
+					),
+				);
+			}
+			if (qa_get_state() == 'password-changed') {
+				$this->content['form_profile']['ok'] = qa_lang_html('users/password_changed');
+			}
+		}
+		qa_html_theme_base::main();
+	}
+
+}

--- a/qa-admin-change-password-page.php
+++ b/qa-admin-change-password-page.php
@@ -37,7 +37,7 @@ class qa_change_admin_password {
 	function process_request($request)
 	{
 		if (!qa_is_http_post()) {
-			qa_redirect('/');
+			qa_redirect();
 		};
 		$qa_content = qa_content_prepare();
 		$errors = array();

--- a/qa-admin-change-password-page.php
+++ b/qa-admin-change-password-page.php
@@ -1,0 +1,104 @@
+<?php
+
+class qa_change_admin_password {
+
+	var $directory;
+	var $urltoroot;
+
+
+	function load_module($directory, $urltoroot)
+	{
+		$this->directory=$directory;
+		$this->urltoroot=$urltoroot;
+	}
+
+
+	function suggest_requests() // for display in admin interface
+	{
+		return array(
+			array(
+				'title' => 'Admin Change Password',
+				'request' => 'change-password',
+				'nav' => 'none', // 'M'=main, 'F'=footer, 'B'=before main, 'O'=opposite main, null=none
+			),
+		);
+	}
+
+
+	function match_request($request)
+	{
+		if ($request=='change-password')
+			return true;
+
+		return false;
+	}
+
+
+	function process_request($request)
+	{
+		if (!qa_is_http_post()) {
+			qa_redirect('/');
+		};
+		$qa_content = qa_content_prepare();
+		$errors = array();
+		$dochangepassword = qa_post_text('dochangepassword');
+
+		if ($dochangepassword) {
+			require_once QA_INCLUDE_DIR.'app/users-edit.php';
+
+			$inoldpassword = qa_post_text('oldpassword');
+			$innewpassword1 = qa_post_text('newpassword1');
+			$innewpassword2 = qa_post_text('newpassword2');
+			$userid = qa_post_text('userid');
+			$useraccount = qa_db_select_with_pending(qa_db_user_account_selectspec($userid, true));
+			$haspassword = isset($useraccount['passsalt']) && isset($useraccount['passcheck']);
+			$code = qa_post_text('code');
+
+			if (!qa_check_form_security_code('password', $code))
+				$errors['page'] = qa_lang_html('misc/form_security_again');
+
+			else {
+				$errors = array();
+
+				if ($haspassword && (strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck'])))
+					$errors['oldpassword'] = qa_lang('users/password_wrong');
+
+				$useraccount['password'] = $inoldpassword;
+				$errors = $errors + qa_password_validate($innewpassword1, $useraccount); // array union
+
+				if ($innewpassword1 != $innewpassword2)
+					$errors['newpassword2'] = qa_lang('users/password_mismatch');
+
+				if (empty($errors)) {
+					qa_db_user_set_password($userid, $innewpassword1);
+					// qa_db_user_set($userid, 'sessioncode', ''); // stop old 'Remember me' style logins from still working
+					// qa_set_logged_in_user($userid, $useraccount['handle'], false, $useraccount['sessionsource']); // reinstate this specific session
+
+					qa_report_event('au_password', $userid, $useraccount['handle'], qa_cookie_get());
+
+					qa_redirect('user/'.$useraccount['handle'], array('state' => 'password-changed'));
+				}
+			}
+
+		}
+
+		$qa_content['title'] = 'Test Plugin';
+		// $qa_content['error'] = '';
+		if (!empty($errors)) {
+			$qa_content['custom'] .= '<ul>';
+			foreach ($errors as $error) {
+				$qa_content['custom'] .= '<li>'.$error.'</li>';
+			}
+			$qa_content['custom'] .= '</ul>';
+			$qa_content['custom'] .= '変更できませんでした。<br>';
+			$qa_content['custom'] .= '<a href="user/'.$useraccount['handle'].'">戻る</a>';
+		}
+		return $qa_content;
+	}
+
+}
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+	Plugin Name: Admin Change Password
+	Plugin URI:
+	Plugin Update Check URI:
+	Plugin Description: An administrator can change the user's other passwords.
+	Plugin Version: 0.1
+	Plugin Date: 2016-07-01
+	Plugin Author: 38qa.net
+	Plugin Author URI:
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+*/
+
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+		header('Location: ../../');
+		exit;
+}
+
+// layer
+qa_register_plugin_layer('qa-admin-change-password-layer.php', 'Admin Change Password Layer');
+// page
+qa_register_plugin_module('page', 'qa-admin-change-password-page.php', 'qa_change_admin_password', 'Admin Change Password');
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/


### PR DESCRIPTION
- 管理者がユーザー情報の編集ボタンを押した時に、パスワード変更フォームを追加
- 実際の変更処理は /change-password で行う
